### PR TITLE
Implemented pose prior, joint regressor, joint prior

### DIFF
--- a/AvatarDemo.cpp
+++ b/AvatarDemo.cpp
@@ -5,6 +5,8 @@
 #include <opencv2/face.hpp>
 #include <opencv2/ximgproc.hpp>
 
+#define GLOG_minloglevel 3
+
 // OpenARK Libraries
 #include "Version.h"
 #ifdef PMDSDK_ENABLED
@@ -181,35 +183,142 @@ static void toSMPLJoints(const cv::Mat & xyzMap, const std::vector<cv::Point> & 
 
     out = cloud((int)smpl_j::_COUNT, 3);
     out.row(smpl_j::PELVIS) = mpi.row(mpi_j::LEFT_HIP) * 0.5 + mpi.row(mpi_j::RIGHT_HIP) * 0.5 - forward * unit * 0.42;
-    out.row(smpl_j::R_HIP) = mpi.row(mpi_j::LEFT_HIP) * 0.8 + mpi.row(mpi_j::LEFT_KNEE) * 0.2 - forward * unit * 0.3;
-    out.row(smpl_j::L_HIP) = mpi.row(mpi_j::RIGHT_HIP) * 0.8 + mpi.row(mpi_j::RIGHT_KNEE) * 0.2 - forward * unit * 0.3;
-    out.row(smpl_j::R_KNEE) = mpi.row(mpi_j::LEFT_KNEE);
-    out.row(smpl_j::L_KNEE) = mpi.row(mpi_j::RIGHT_KNEE);
-    out.row(smpl_j::R_ANKLE) = mpi.row(mpi_j::LEFT_ANKLE);
-    out.row(smpl_j::L_ANKLE) = mpi.row(mpi_j::RIGHT_ANKLE);
+    out.row(smpl_j::L_HIP) = mpi.row(mpi_j::LEFT_HIP) * 0.8 + mpi.row(mpi_j::LEFT_KNEE) * 0.2 - forward * unit * 0.3;
+    out.row(smpl_j::R_HIP) = mpi.row(mpi_j::RIGHT_HIP) * 0.8 + mpi.row(mpi_j::RIGHT_KNEE) * 0.2 - forward * unit * 0.3;
+    out.row(smpl_j::L_KNEE) = mpi.row(mpi_j::LEFT_KNEE);
+    out.row(smpl_j::R_KNEE) = mpi.row(mpi_j::RIGHT_KNEE);
+    out.row(smpl_j::L_ANKLE) = mpi.row(mpi_j::LEFT_ANKLE);
+    out.row(smpl_j::R_ANKLE) = mpi.row(mpi_j::RIGHT_ANKLE);
     out.row(smpl_j::SPINE1) = mpi.row(mpi_j::CHEST) * 0.4 + mpi.row(mpi_j::LEFT_HIP) * 0.3 + mpi.row(mpi_j::RIGHT_HIP) * 0.3 - forward * unit * 0.6;
     out.row(smpl_j::SPINE2) = mpi.row(mpi_j::CHEST) - forward * unit * 0.65;
     out.row(smpl_j::SPINE3) = mpi.row(mpi_j::CHEST) * 0.8 + mpi.row(mpi_j::LEFT_SHOULDER) * 0.1 + mpi.row(mpi_j::RIGHT_SHOULDER) * 0.1 - forward * unit * 0.35;
     out.row(smpl_j::HEAD) = mpi.row(mpi_j::NECK) * 0.8 + mpi.row(mpi_j::HEAD) * 0.2 - up * unit * 0.2;
     out.row(smpl_j::NECK) = mpi.row(mpi_j::NECK) * 0.3 + mpi.row(mpi_j::LEFT_SHOULDER) * 0.35 + mpi.row(mpi_j::RIGHT_SHOULDER) * 0.35;
-    out.row(smpl_j::R_SHOULDER) = mpi.row(mpi_j::LEFT_SHOULDER) - up * unit * 0.25 + forward * unit * 0.1;
-    out.row(smpl_j::L_SHOULDER) = mpi.row(mpi_j::RIGHT_SHOULDER) - up * unit * 0.25 + forward * unit * 0.1;
-    out.row(smpl_j::R_ELBOW) = mpi.row(mpi_j::LEFT_ELBOW);
-    out.row(smpl_j::L_ELBOW) = mpi.row(mpi_j::RIGHT_ELBOW);
-    out.row(smpl_j::R_WRIST) = mpi.row(mpi_j::LEFT_WRIST);
-    out.row(smpl_j::L_WRIST) = mpi.row(mpi_j::RIGHT_WRIST);
-    out.row(smpl_j::R_HAND) = mpi.row(mpi_j::LEFT_WRIST) * 1.4 - mpi.row(mpi_j::LEFT_ELBOW) * 0.4;
-    out.row(smpl_j::L_HAND) = mpi.row(mpi_j::RIGHT_WRIST) * 1.4 - mpi.row(mpi_j::RIGHT_ELBOW) * 0.4;
-    out.row(smpl_j::R_COLLAR) = mpi.row(mpi_j::LEFT_SHOULDER) * 0.75 + mpi.row(mpi_j::RIGHT_SHOULDER) * 0.25 - up * unit * 0.5;
-    out.row(smpl_j::L_COLLAR) = mpi.row(mpi_j::LEFT_SHOULDER) * 0.25 + mpi.row(mpi_j::RIGHT_SHOULDER) * 0.75 - up * unit * 0.5;
-    out.row(smpl_j::R_FOOT) = mpi.row(mpi_j::LEFT_ANKLE) * 1.1 -  mpi.row(mpi_j::LEFT_KNEE) * 0.1 + forward * unit;
-    out.row(smpl_j::L_FOOT) = mpi.row(mpi_j::RIGHT_ANKLE) * 1.1 -  mpi.row(mpi_j::RIGHT_KNEE) * 0.1 + forward * unit;
+    out.row(smpl_j::L_SHOULDER) = mpi.row(mpi_j::LEFT_SHOULDER) - up * unit * 0.25 + forward * unit * 0.1;
+    out.row(smpl_j::R_SHOULDER) = mpi.row(mpi_j::RIGHT_SHOULDER) - up * unit * 0.25 + forward * unit * 0.1;
+    out.row(smpl_j::L_ELBOW) = mpi.row(mpi_j::LEFT_ELBOW);
+    out.row(smpl_j::R_ELBOW) = mpi.row(mpi_j::RIGHT_ELBOW);
+    out.row(smpl_j::L_WRIST) = mpi.row(mpi_j::LEFT_WRIST);
+    out.row(smpl_j::R_WRIST) = mpi.row(mpi_j::RIGHT_WRIST);
+    out.row(smpl_j::L_HAND) = mpi.row(mpi_j::LEFT_WRIST) * 1.4 - mpi.row(mpi_j::LEFT_ELBOW) * 0.4;
+    out.row(smpl_j::R_HAND) = mpi.row(mpi_j::RIGHT_WRIST) * 1.4 - mpi.row(mpi_j::RIGHT_ELBOW) * 0.4;
+    out.row(smpl_j::L_COLLAR) = mpi.row(mpi_j::LEFT_SHOULDER) * 0.75 + mpi.row(mpi_j::RIGHT_SHOULDER) * 0.25 - up * unit * 0.5;
+    out.row(smpl_j::R_COLLAR) = mpi.row(mpi_j::LEFT_SHOULDER) * 0.25 + mpi.row(mpi_j::RIGHT_SHOULDER) * 0.75 - up * unit * 0.5;
+    out.row(smpl_j::L_FOOT) = mpi.row(mpi_j::LEFT_ANKLE) * 1.1 -  mpi.row(mpi_j::LEFT_KNEE) * 0.1 + forward * unit;
+    out.row(smpl_j::R_FOOT) = mpi.row(mpi_j::RIGHT_ANKLE) * 1.1 -  mpi.row(mpi_j::RIGHT_KNEE) * 0.1 + forward * unit;
 
     for (int i = 0; i < out.rows(); ++i) {
         out.row(i) -= forward * unit * 0.2;
         if (out.row(i).x() < -1e10 || std::isnan(out.row(i).x())) {
             out.row(i).x() = NAN;
         }
+    }
+}
+
+// open a gui for interacting with avatar
+void __avatarGUI(const std::string & human_model_path, const std::vector<std::string> & shape_keys)
+{
+    // build file names and paths
+    HumanAvatar ava(human_model_path, shape_keys);
+
+    cv::namedWindow("Body Shape");
+    cv::namedWindow("Body Pose");
+    std::vector<int> pcw(shape_keys.size(), 1000), p_pcw(shape_keys.size(), 0);
+
+    // define some axes
+    const Eigen::Vector3d AXISX(1, 0, 0), AXISY(0, 1, 0), AXISZ(0, 0, 1);
+
+    // Body pose control definitions (currently this control system only supports rotation along one axis per body part)
+    const std::vector<std::string> CTRL_NAMES       = {"L HIP",      "R HIP",      "L KNEE",      "R KNEE",      "L ANKLE",      "R ANKLE",      "L ARM",        "R ARM",        "L ELBOW",      "R ELBOW",      "HEAD",      "SPINE2",     "ROOT"};
+    using jnt_t = HumanAvatar::JointType;
+    const std::vector<jnt_t> CTRL_JNT               = {jnt_t::L_HIP, jnt_t::R_HIP, jnt_t::L_KNEE, jnt_t::R_KNEE, jnt_t::L_ANKLE, jnt_t::R_ANKLE, jnt_t::L_ELBOW, jnt_t::R_ELBOW, jnt_t::L_WRIST, jnt_t::R_WRIST, jnt_t::HEAD, jnt_t::SPINE2, jnt_t::ROOT};
+    const std::vector<Eigen::Vector3d> CTRL_AXIS    = {AXISX,        AXISX,        AXISX,         AXISX,         AXISX,          AXISX,          AXISY,          AXISY,          AXISY,          AXISY,          AXISX,       AXISX,         AXISY};
+    const int N_CTRL = (int)CTRL_NAMES.size();
+
+    std::vector<int> ctrlw(N_CTRL, 1000), p_ctrlw(N_CTRL, 0);
+
+    // Body shapekeys are defined in SMPL model files.
+    int pifx = 0, pify = 0, picx = 0, picy = 0, pframeID = -1;
+    cv::resizeWindow("Body Shape", cv::Size(400, 700));
+    cv::resizeWindow("Body Pose", cv::Size(400, 700));
+    cv::resizeWindow("Body Scale", cv::Size(400, 700));
+    for (int i = 0; i < N_CTRL; ++i) {
+        cv::createTrackbar(CTRL_NAMES[i], "Body Pose", &ctrlw[i], 2000);
+    }
+    for (int i = 0; i < (int)pcw.size(); ++i) {
+        cv::createTrackbar("PC" + std::to_string(i), "Body Shape", &pcw[i], 2000);
+    }
+
+    auto viewer = Visualizer::getPCLVisualizer();
+
+    int vp1 = 0;
+    viewer->setWindowName("3D View");
+    viewer->setCameraClipDistances(0.0, 1000.0);
+
+    volatile bool interrupt = false;
+    viewer->registerKeyboardCallback([&interrupt](const pcl::visualization::KeyboardEvent & evt) {
+        unsigned char k = evt.getKeyCode();
+        if (k == 'Q' || k == 'q' || k == 27) {
+            interrupt = true;
+        }
+    });
+
+    while (!interrupt) {
+        bool controlsChanged = false;
+        for (int i = 0; i < N_CTRL; ++i) {
+            if (ctrlw[i] != p_ctrlw[i]) {
+                controlsChanged = true;
+                break;
+            }
+        }
+        for (int i = 0; i < (int)pcw.size(); ++i) {
+            if (pcw[i] != p_pcw[i]) {
+                controlsChanged = true;
+                break;
+            }
+        }
+        if (controlsChanged) {
+            viewer->removeAllPointClouds(vp1);
+            viewer->removeAllShapes(vp1);
+            HumanAvatar::Cloud_T::Ptr depthPC, depthPCPartial;
+            ava.update();
+
+            viewer->addPointCloud<HumanAvatar::Point_T>(ava.getCloud(), "vp1_cloudHM", vp1);
+            ava.visualize(viewer, "vp1_", vp1);
+
+            for (int i = 0; i < N_CTRL; ++i) {
+                double angle = (ctrlw[i] - 1000) / 1000.0 * PI;
+                ava.setRotation(CTRL_JNT[i], Eigen::AngleAxisd(angle, CTRL_AXIS[i]));
+            }
+
+            for (int i = 0; i < (int)pcw.size(); ++i) {
+                ava.setKeyWeight(i, (float)(pcw[i] - 1000) / 500.0);
+            }
+
+            ava.setCenterPosition(Eigen::Vector3d(0, 0, -3));
+            ava.update();
+
+            for (int k = 0; k < (int) pcw.size(); ++k) {
+                p_pcw[k] = pcw[k] = (int) (ava.getKeyWeight(k) * 500.0 + 1000);
+                cv::setTrackbarPos("PC" + std::to_string(k), "Body Shape", pcw[k]);
+            }
+
+            double prior = ava.posePrior.residual(ava.smplParams()).squaredNorm();
+            // show pose prior value
+            if (!viewer->updateText("-log likelihood: " + std::to_string(prior), 10, 20, 15, 1.0, 1.0, 1.0, "poseprior_disp")) {
+                viewer->addText("-log likelihood: " + std::to_string(prior), 10, 20, 15, 1.0, 1.0, 1.0, "poseprior_disp");
+            }
+
+            viewer->removePointCloud("vp1_cloudHM");
+            viewer->addPointCloud<HumanAvatar::Point_T>(ava.getCloud(), "vp1_cloudHM");
+            ava.visualize(viewer, "vp1_", vp1);
+            viewer->spinOnce();
+        }
+        for (int i = 0; i < N_CTRL; ++i) p_ctrlw[i] = ctrlw[i];
+        for (int i = 0; i < (int)pcw.size(); ++i) p_pcw[i] = pcw[i];
+
+        int k = cv::waitKey(100);
+        if (k == 'q' || k == 27) break;
     }
 }
 
@@ -220,7 +329,6 @@ int main(int argc, char ** argv) {
     // seed the rng
     srand(time(NULL));
 
-    const std::string IMG_PATH = "C:\\dev\\OpenARK_dataset\\human-basic-rgb-D435-tiny\\capture_15.yml";
     // gender-neutral model
     const std::string HUMAN_MODEL_PATH = "C:/dev/SMPL/models/basicModel_neutral_lbs_10_207_0_v1.0.0/";
 
@@ -228,6 +336,9 @@ int main(int argc, char ** argv) {
 												 "shape003.pcd", "shape004.pcd", "shape005.pcd",
 												 "shape006.pcd", "shape007.pcd", "shape008.pcd", 
 												 "shape009.pcd"};
+
+    // UNCOMMENT following line to see the GUI for manipulating SMPL avatar pose, shape, etc.
+    //__avatarGUI(HUMAN_MODEL_PATH, SHAPE_KEYS); return 0;
 
 	auto path = "C:\\dev\\OpenARK_dataset\\human-wave-1";
 	const auto camera = std::make_shared<MockCamera>(path);
@@ -241,8 +352,6 @@ int main(int argc, char ** argv) {
 		cv::Mat xyzMap = camera->getXYZMap();
 		cv::Mat rgbMap = camera->getRGBMap();
 		std::vector<cv::Point> rgbJoints = camera->getJoints();
-
-		viewer->removeAllPointClouds();
 			
 		// segmentation using agglomerate clustering
 		cv::Mat out;
@@ -263,37 +372,37 @@ int main(int argc, char ** argv) {
 
 		cv::imshow("Fill", out);
 		cv::Mat xyzVis;
-		Visualizer::visualizeXYZMap(xyzMap, xyzVis, 2.5f);
+		Visualizer::visualizeXYZMap(xyzMap, xyzVis, 7.5f);
 		cv::imshow("Depth Map", xyzVis);
 		cv::imshow("RGB", rgbMap);
 
-		ava.setCenterPosition(util::cloudCenter(humanCloudRaw));
-		ava.update();
-		ava.alignToJoints(xyzJoints);
+        if (i == 0) {
+            ava.setCenterPosition(util::cloudCenter(humanCloudRaw));
+            ava.update();
+            ava.alignToJoints(xyzJoints);
+        }
+        else {
+            ava.updateJointsPrior(xyzJoints);
+        }
 		ava.update();
 
-		const std::string MODEL_CLOUD_NAME = "model_cloud" + i, DATA_CLOUD_NAME = "data_cloud" + i;
 
 		// visualize
-		viewer->addPointCloud<pcl::PointXYZ>(humanCloud, DATA_CLOUD_NAME, vp0);
-		std::cout << "Data (Human) Points: " << humanCloud->size() << ". "
-			        << "Model (Avatar) Points: " << ava.getCloud()->size() << "\n";
-
-		viewer->addPointCloud<HumanAvatar::Point_T>(ava.getCloud(), MODEL_CLOUD_NAME, vp0);
 		if (i == 0) {
+			std::cout << "Fitting" << std::endl;
 			ava.fit(humanCloud);
-			cout << "Fitting" << endl;
 		}
 		else {
+			std::cout << "Tracking" << std::endl;
 			ava.fitTrack(humanCloud);
-			cout << "Tracking" << endl;
 		}
 			
 		ava.visualize(viewer, "o1_ava_", vp1);
 		ava.visualize(viewer, "ava_", vp0);
-		viewer->removePointCloud(MODEL_CLOUD_NAME, vp0);
-		viewer->addPointCloud<HumanAvatar::Point_T>(ava.getCloud(), MODEL_CLOUD_NAME, vp0);
-		viewer->addPointCloud<HumanAvatar::Point_T>(ava.getCloud(), MODEL_CLOUD_NAME + "_o1", vp1);
+
+		const std::string DATA_CLOUD_NAME = "data_cloud";
+        viewer->removePointCloud(DATA_CLOUD_NAME, vp0);
+        viewer->addPointCloud<pcl::PointXYZ>(humanCloud, DATA_CLOUD_NAME, vp0);
 
 		viewer->spinOnce();
 		int c = cv::waitKey(1);

--- a/FramePlane.cpp
+++ b/FramePlane.cpp
@@ -36,14 +36,14 @@ namespace ark {
 
     bool FramePlane::touching(const Vec3f & point, const Point2i & index, float norm_thresh, bool check_bounds) const
     {
-        if (normToPoint(point) > norm_thresh) return false;
+        if (squaredDistanceToPoint(point) > norm_thresh) return false;
         else if (!check_bounds) return true;
         return cv::pointPolygonTest(boundingRect, index, false) >= 0;
     }
 
-    float FramePlane::normToPoint(const Vec3f & point) const
+    float FramePlane::squaredDistanceToPoint(const Vec3f & point) const
     {
-        return util::pointPlaneNorm(point, equation);
+        return util::pointPlaneSquaredDistance(point, equation);
     }
 
     float FramePlane::distanceToPoint(const Vec3f & point) const

--- a/HandDemo.cpp
+++ b/HandDemo.cpp
@@ -161,7 +161,7 @@ int main() {
 
                         float norm = util::pointPlaneNorm(xyz, planes[i]->equation);
 
-                        float fact = std::max(0.0, 0.5f - norm / params->handPlaneMinNorm / 8.0f);
+                        float fact = std::max(0.0, 0.5f - norm / params->handPlaneMinSqrDist / 8.0f);
                         if (fact == 0.0f) continue;
 
                         outPtr[col] += (color - (cv::Vec3s)outPtr[col]) * fact;

--- a/HandDetector.cpp
+++ b/HandDetector.cpp
@@ -50,7 +50,7 @@ namespace ark {
                 for (FramePlane::Ptr plane : planes) {
                     if (plane->getDepth() < params->handMaxDepth)
                         util::removePlane<uchar>(image, floodFillMap, plane->equation,
-                            params->handPlaneMinNorm);
+                            params->handPlaneMinSqrDist);
                 }
             }
         }

--- a/PlaneDetector.cpp
+++ b/PlaneDetector.cpp
@@ -192,8 +192,8 @@ namespace ark {
             int goodPts = 0;
 
             for (uint j = 0; j < SZ; ++j) {
-                float norm = util::pointPlaneNorm((*planePointsXYZ[i])[j], planeEquation[i]);
-                if (norm < params->handPlaneMinNorm) {
+                float norm = util::pointPlaneSquaredDistance((*planePointsXYZ[i])[j], planeEquation[i]);
+                if (norm < params->handPlaneMinSqrDist) {
                     ++goodPts;
                 }
             }

--- a/Util.cpp
+++ b/Util.cpp
@@ -131,28 +131,28 @@ namespace ark {
         template double euclideanDistance<double>(const cv::Vec<double, 3> & pt1, const cv::Vec<double, 3> & pt2);
 
         template<class Param_T>
-        float pointLineNorm(const cv::Point_<Param_T> & p, const cv::Point_<Param_T> & a, const cv::Point_<Param_T> & b, int cv_norm_type)
+        float pointLineDistance(const cv::Point_<Param_T> & p, const cv::Point_<Param_T> & a, const cv::Point_<Param_T> & b, int cv_norm_type)
         {
             cv::Point_<Param_T> ap = a - p, ab = b - a;
             return util::norm(ap - (ap.dot(ab) / ab.dot(ab)) * ab, cv_norm_type);
         }
-        template float pointLineNorm<int>(const cv::Point_<int> & p, const cv::Point_<int> & a, const cv::Point_<int> & b, int cv_norm_type);
-        template float pointLineNorm<float>(const cv::Point_<float> & p, const cv::Point_<float> & a, const cv::Point_<float> & b, int cv_norm_type);
-        template float pointLineNorm<double>(const cv::Point_<double> & p, const cv::Point_<double> & a, const cv::Point_<double> & b, int cv_norm_type);
+        template float pointLineDistance<int>(const cv::Point_<int> & p, const cv::Point_<int> & a, const cv::Point_<int> & b, int cv_norm_type);
+        template float pointLineDistance<float>(const cv::Point_<float> & p, const cv::Point_<float> & a, const cv::Point_<float> & b, int cv_norm_type);
+        template float pointLineDistance<double>(const cv::Point_<double> & p, const cv::Point_<double> & a, const cv::Point_<double> & b, int cv_norm_type);
 
         template<class Param_T>
-        Param_T pointLineNorm(const cv::Vec<Param_T, 3> & p, const cv::Vec<Param_T, 3> & a, const cv::Vec<Param_T, 3> & b, int cv_norm_type)
+        Param_T pointLineDistance(const cv::Vec<Param_T, 3> & p, const cv::Vec<Param_T, 3> & a, const cv::Vec<Param_T, 3> & b, int cv_norm_type)
         {
             cv::Vec<Param_T, 3> ap = p - a, ab = b - a;
             return cv::norm(ap - (ap.dot(ab) / ab.dot(ab)) * ab, cv_norm_type);
         }
-        template uchar pointLineNorm<uchar>(const cv::Vec<uchar, 3> & p, const cv::Vec<uchar, 3> & a, const cv::Vec<uchar, 3> & b, int cv_norm_type);
-        template int pointLineNorm<int>(const cv::Vec<int, 3> & p, const cv::Vec<int, 3> & a, const cv::Vec<int, 3> & b, int cv_norm_type);
-        template float pointLineNorm<float>(const cv::Vec<float, 3> & p, const cv::Vec<float, 3> & a, const cv::Vec<float, 3> & b, int cv_norm_type);
-        template double pointLineNorm<double>(const cv::Vec<double, 3> & p, const cv::Vec<double, 3> & a, const cv::Vec<double, 3> & b, int cv_norm_type);
+        template uchar pointLineDistance<uchar>(const cv::Vec<uchar, 3> & p, const cv::Vec<uchar, 3> & a, const cv::Vec<uchar, 3> & b, int cv_norm_type);
+        template int pointLineDistance<int>(const cv::Vec<int, 3> & p, const cv::Vec<int, 3> & a, const cv::Vec<int, 3> & b, int cv_norm_type);
+        template float pointLineDistance<float>(const cv::Vec<float, 3> & p, const cv::Vec<float, 3> & a, const cv::Vec<float, 3> & b, int cv_norm_type);
+        template double pointLineDistance<double>(const cv::Vec<double, 3> & p, const cv::Vec<double, 3> & a, const cv::Vec<double, 3> & b, int cv_norm_type);
 
         template<class Param_T>
-        float pointLineSegmentNorm(const cv::Point_<Param_T>& p, const cv::Point_<Param_T>& a, const cv::Point_<Param_T>& b, int cv_norm_type)
+        float pointLineSegmentDistance(const cv::Point_<Param_T>& p, const cv::Point_<Param_T>& a, const cv::Point_<Param_T>& b, int cv_norm_type)
         {
             const cv::Point_<Param_T> ab = b - a, ap = p - a;
             const Param_T l2 = util::norm(ab, cv_norm_type);
@@ -160,12 +160,12 @@ namespace ark {
             float t = std::max<Param_T>(0, std::min<Param_T>(1, ap.dot(ab) / l2));
             return util::norm(ap - t * ab, cv_norm_type);
         }
-        template float pointLineSegmentNorm<int>(const cv::Point_<int> & p, const cv::Point_<int> & a, const cv::Point_<int> & b, int cv_norm_type);
-        template float pointLineSegmentNorm<float>(const cv::Point_<float> & p, const cv::Point_<float> & a, const cv::Point_<float> & b, int cv_norm_type);
-        template float pointLineSegmentNorm<double>(const cv::Point_<double> & p, const cv::Point_<double> & a, const cv::Point_<double> & b, int cv_norm_type);
+        template float pointLineSegmentDistance<int>(const cv::Point_<int> & p, const cv::Point_<int> & a, const cv::Point_<int> & b, int cv_norm_type);
+        template float pointLineSegmentDistance<float>(const cv::Point_<float> & p, const cv::Point_<float> & a, const cv::Point_<float> & b, int cv_norm_type);
+        template float pointLineSegmentDistance<double>(const cv::Point_<double> & p, const cv::Point_<double> & a, const cv::Point_<double> & b, int cv_norm_type);
 
         template<class Param_T>
-        Param_T pointLineSegmentNorm(const cv::Vec<Param_T, 3>& p, const cv::Vec<Param_T, 3>& a, const cv::Vec<Param_T, 3> & b, int cv_norm_type)
+        Param_T pointLineSegmentDistance(const cv::Vec<Param_T, 3>& p, const cv::Vec<Param_T, 3>& a, const cv::Vec<Param_T, 3> & b, int cv_norm_type)
         {
             const cv::Vec<Param_T, 3> ab = b - a, ap = p - a;
             const Param_T l2 = cv::norm(ab, cv_norm_type);
@@ -173,10 +173,10 @@ namespace ark {
             Param_T t = std::max<Param_T>(0, std::min<Param_T>(1, ap.dot(ab) / l2));
             return cv::norm(ap - t * ab, cv_norm_type);
         }
-        template uchar pointLineSegmentNorm<uchar>(const cv::Vec<uchar, 3> & p, const cv::Vec<uchar, 3> & a, const cv::Vec<uchar, 3> & b, int cv_norm_type);
-        template int pointLineSegmentNorm<int>(const cv::Vec<int, 3> & p, const cv::Vec<int, 3> & a, const cv::Vec<int, 3> & b, int cv_norm_type);
-        template float pointLineSegmentNorm<float>(const cv::Vec<float, 3> & p, const cv::Vec<float, 3> & a, const cv::Vec<float, 3> & b, int cv_norm_type);
-        template double pointLineSegmentNorm<double>(const cv::Vec<double, 3> & p, const cv::Vec<double, 3> & a, const cv::Vec<double, 3> & b, int cv_norm_type);
+        template uchar pointLineSegmentDistance<uchar>(const cv::Vec<uchar, 3> & p, const cv::Vec<uchar, 3> & a, const cv::Vec<uchar, 3> & b, int cv_norm_type);
+        template int pointLineSegmentDistance<int>(const cv::Vec<int, 3> & p, const cv::Vec<int, 3> & a, const cv::Vec<int, 3> & b, int cv_norm_type);
+        template float pointLineSegmentDistance<float>(const cv::Vec<float, 3> & p, const cv::Vec<float, 3> & a, const cv::Vec<float, 3> & b, int cv_norm_type);
+        template double pointLineSegmentDistance<double>(const cv::Vec<double, 3> & p, const cv::Vec<double, 3> & a, const cv::Vec<double, 3> & b, int cv_norm_type);
 
         template<class T>
         T pointPlaneDistance(const cv::Vec<T, 3> & pt, T a, T b, T c)
@@ -198,24 +198,24 @@ namespace ark {
         template double pointPlaneDistance<double>(const cv::Vec<double, 3> & pt, const cv::Vec<double, 3> & eqn);
 
         template<class T>
-        T pointPlaneNorm(const cv::Vec<T, 3> & pt, T a, T b, T c)
+        T pointPlaneSquaredDistance(const cv::Vec<T, 3> & pt, T a, T b, T c)
         {
             T alpha = (a*pt[0] + b*pt[1] - pt[2] + c);
             return alpha * alpha / (a*a + b*b + 1.0);
         }
 
-        template float pointPlaneNorm<float>(const cv::Vec<float, 3> & pt, float a, float b, float c);
-        template double pointPlaneNorm<double>(const cv::Vec<double, 3> & pt, double a, double b, double c);
+        template float pointPlaneSquaredDistance<float>(const cv::Vec<float, 3> & pt, float a, float b, float c);
+        template double pointPlaneSquaredDistance<double>(const cv::Vec<double, 3> & pt, double a, double b, double c);
 
         template<class T>
-        T pointPlaneNorm(const cv::Vec<T, 3> & pt, const cv::Vec<T, 3> & eqn)
+        T pointPlaneSquaredDistance(const cv::Vec<T, 3> & pt, const cv::Vec<T, 3> & eqn)
         {
             T alpha = eqn[0] * pt[0] + eqn[1] * pt[1] - pt[2] + eqn[2];
             return alpha * alpha / (eqn[0] * eqn[0] + eqn[1] * eqn[1] + 1.0);
         }
 
-        template float pointPlaneNorm<float>(const cv::Vec<float, 3> & pt, const cv::Vec<float, 3> & eqn);
-        template double pointPlaneNorm<double>(const cv::Vec<double, 3> & pt, const cv::Vec<double, 3> & eqn);
+        template float pointPlaneSquaredDistance<float>(const cv::Vec<float, 3> & pt, const cv::Vec<float, 3> & eqn);
+        template double pointPlaneSquaredDistance<double>(const cv::Vec<double, 3> & pt, const cv::Vec<double, 3> & eqn);
 
         template<class T, int N>
         cv::Vec<T, N> linearRegression(const std::vector<cv::Vec<T, N>> & points, int num_points)
@@ -296,7 +296,7 @@ namespace ark {
                 // compute number of inliers
                 int inliers = 0;
                 for (int i = 0; i < num_points; ++i) {
-                    T norm = util::pointPlaneNorm(points[i], eqn);
+                    T norm = util::pointPlaneSquaredDistance(points[i], eqn);
                     if (norm < thresh) ++inliers;
                 }
 
@@ -379,7 +379,7 @@ namespace ark {
                     }
 
                     //std::cout << (refPtr[col], plane_equation) << endl;
-                    if (pointPlaneNorm(refPtr[col], plane_equation) < threshold) {
+                    if (pointPlaneSquaredDistance(refPtr[col], plane_equation) < threshold) {
                         // found nearby plane, remove point (i.e. set to 0)
                         imgPtr[col] = 0;
                     }

--- a/include/DetectionParams.h
+++ b/include/DetectionParams.h
@@ -263,12 +263,12 @@ namespace ark {
         double centroidDefectFingerAngleMin = 0.20 * PI;
 
         /**
-         * minimum norm (distance squared; in m^2) between a hand and a plane.
+         * minimum distance squared (in m^2) between a hand and a plane.
          * points closer to the plane are not considered during hand detection
          * so that the hand is isolated from the planar surfaces are removed.
          * default: 0.000075
          */
-        double handPlaneMinNorm = 0.000075;
+        double handPlaneMinSqrDist = 0.000075;
 
         // ** Plane detection parameters ** 
 

--- a/include/FramePlane.h
+++ b/include/FramePlane.h
@@ -78,7 +78,7 @@ namespace ark {
          * @param point the point
          * @return euclidean distance
          */
-        float normToPoint(const Vec3f & point) const;
+        float squaredDistanceToPoint(const Vec3f & point) const;
 
         /**
          * Find the euclidean distance from the plane to a given point

--- a/include/Util.h
+++ b/include/Util.h
@@ -83,7 +83,7 @@ namespace ark {
         float euclideanDistance(const cv::Point_<T> & pt1, const cv::Point_<T> & pt2);
 
         /**
-        * Get L2 norm (euclidean distance) between two 3D points.
+        * Get euclidean distance between two 3D points.
         * @param pt1 point 1
         * @param pt2 point 2
         * @return euclidean distance
@@ -92,43 +92,43 @@ namespace ark {
         T euclideanDistance(const cv::Vec<T, 3> & pt1, const cv::Vec<T, 3> & pt2);
 
         /**
-        * Compute the norm (squared L2 by default) between a point and any point on a  line
+        * Compute the squared distance between a point and any point on a  line
         * @param v the point
         * @param a, b two points on the line
         * @param cv_norm_type type of norm to use (cv::NORM_XYZ); defaults to square of L2
         */
         template<class Param_T>
-        float pointLineNorm(const cv::Point_<Param_T> & p, const cv::Point_<Param_T> & a, const cv::Point_<Param_T> & b, int cv_norm_type = cv::NORM_L2SQR);
+        float pointLineDistance(const cv::Point_<Param_T> & p, const cv::Point_<Param_T> & a, const cv::Point_<Param_T> & b, int cv_norm_type = cv::NORM_L2SQR);
 
         /**
-        * Compute the norm (squared L2 by default) between a point and any point on a line
+        * Compute the squared distance between a point and any point on a line
         * @param v the point
         * @param a, b two points on the line
         * @param cv_norm_type type of norm to use (cv::NORM_XYZ); defaults to square of L2
         */
         template<class Param_T>
-        Param_T pointLineNorm(const cv::Vec<Param_T, 3> & p, const cv::Vec<Param_T, 3> & a, const cv::Vec<Param_T, 3> & b, int cv_norm_type = cv::NORM_L2SQR);
+        Param_T pointLineDistance(const cv::Vec<Param_T, 3> & p, const cv::Vec<Param_T, 3> & a, const cv::Vec<Param_T, 3> & b, int cv_norm_type = cv::NORM_L2SQR);
 
         /**
-        * Compute the norm (squared L2 by default) between a point and any point on a line segment
+        * Compute the squared distance between a point and any point on a line segment
         * @param v the point
         * @param a, b end points of the line segment
         * @param cv_norm_type type of norm to use (cv::NORM_XYZ); defaults to square of L2
         */
         template<class Param_T>
-        float pointLineSegmentNorm(const cv::Point_<Param_T> & p, const cv::Point_<Param_T> & a, const cv::Point_<Param_T> & b, int cv_norm_type = cv::NORM_L2SQR);
+        float pointLineSegmentDistance(const cv::Point_<Param_T> & p, const cv::Point_<Param_T> & a, const cv::Point_<Param_T> & b, int cv_norm_type = cv::NORM_L2SQR);
 
         /*
-        * Compute the norm (squared L2 by default) between a point and any point on a line segment
+        * Compute the squared distance between a point and any point on a line segment
         * @param v the point
         * @param a, b end points of the line segment
         * @param cv_norm_type type of norm to use (cv::NORM_XYZ); defaults to square of L2
         */
         template<class Param_T>
-        Param_T pointLineSegmentNorm(const cv::Vec<Param_T, 3> & p, const cv::Vec<Param_T, 3> & a, const cv::Vec<Param_T, 3> & b, int cv_norm_type = cv::NORM_L2SQR);
+        Param_T pointLineSegmentDistance(const cv::Vec<Param_T, 3> & p, const cv::Vec<Param_T, 3> & a, const cv::Vec<Param_T, 3> & b, int cv_norm_type = cv::NORM_L2SQR);
 
         /**
-        * Compute the L2 norm (distance) between a point and a plane
+        * Compute the squared distance between a point and a plane
         * Where the plane is defined as: ax + by - z + c = 0
         * @param pt the point
         * @param eqn equation of plane in form: [a, b, c]
@@ -137,7 +137,7 @@ namespace ark {
         template<class T> T pointPlaneDistance(const cv::Vec<T, 3> & pt, const cv::Vec<T, 3> & eqn);
 
         /**
-        * Compute the L2 norm (distance) between a point and a plane
+        * Compute the euclidean distance between a point and a plane
         * Where the plane is defined as: ax + by - z + c = 0
         * @param pt the point
         * @param a, b, c parameters of plane
@@ -146,22 +146,22 @@ namespace ark {
         template<class T> T pointPlaneDistance(const cv::Vec<T, 3> & pt, T a, T b, T c);
 
         /**
-        * Compute the squared L2 norm between a point and a plane
+        * Compute the squared euclidean distance between a point and a plane
         * Where the plane is defined as: ax + by - z + c = 0
         * @param pt the point
         * @param eqn equation of plane in form: [a, b, c]
         * @return squared L2 norm in m^2
         */
-        template<class T> T pointPlaneNorm(const cv::Vec<T, 3> & pt, const cv::Vec<T, 3> & eqn);
+        template<class T> T pointPlaneSquaredDistance(const cv::Vec<T, 3> & pt, const cv::Vec<T, 3> & eqn);
 
         /**
-        * Compute the squared L2 norm (distance squared) between a point and a plane
+        * Compute the squared euclidean distance between a point and a plane
         * Where the plane is defined as: ax + by - z + c = 0
         * @param pt the point
         * @param a, b, c parameters of plane
         * @return squared L2 norm in m^2
         */
-        template<class T> T pointPlaneNorm(const cv::Vec<T, 3> & pt, T a, T b, T c);
+        template<class T> T pointPlaneSquaredDistance(const cv::Vec<T, 3> & pt, T a, T b, T c);
 
         /**
         * Estimate the euclidean distance per pixel around a point on a depth map

--- a/unity/native/UnityInterface.cpp
+++ b/unity/native/UnityInterface.cpp
@@ -1,5 +1,8 @@
 #include <memory>
 #include <utility>
+#include <pcl/point_types.h>
+#include <pcl/point_cloud.h>
+#include <Eigen/Dense>
 
 #include "Core.h"
 #include "UnityInterface.h"
@@ -118,7 +121,7 @@ extern "C" {
     }
 
     float planePointNorm(int plane_id, float x, float y, float z) {
-        return planes->at(plane_id)->normToPoint(ark::Vec3f(x, y, z));
+        return planes->at(plane_id)->squaredDistanceToPoint(ark::Vec3f(x, y, z));
     }
 
     int computeTouches(int hand_id, int plane_id, float thresh) {


### PR DESCRIPTION
This version will require an updated SMPL model: [Download from here](https://drive.google.com/file/d/1mUDOHyJyE37YOGJ5mRgkMGsPUr-uNLFP/view?usp=sharing)

## Changes
- Finished implementing the pose prior (Gaussian Mixture Model)
- Implemented joint regressor to update base joint positions when shape keys change (required according to SMPL paper)
- Removed bone scale parameters and now using joint instead of bone-based rotations
- Include CNN joint detections as part of optimization instead of re-aligning to CNN joint detections at every frame
- Integrated SMPL avatar manipulation/visualization GUI into AvatarDemo.cpp (uncomment line 341 to enable)
  - GUI now displays negative log likelihood of current pose from pose prior

## Minor Changes
- Fixed a build error caused by API changes in UnityInterface.cpp
- Modified some poorly written comments in Util.cpp/h, etc., replacing "norm" with "distance"
- Minor changes to avatar loading to improve efficiency
- Removed some redundant casts from double to ceres Jet
- When downsampling, preserve "critical" points needed by joint regressor

## Todo
- UFK-based tracking
   - Re-initialize when confidence is low
- Improve speed of solver